### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It's up to you to specify your Promise library of choice as a parameter.
 
 ``` javascript
 // Assuming you use Bluebird
-var load = require("promise!./file.js");
+var load = require("es6-promise!./file.js");
 
 // The chunk is not requested until you call the load function
 load(namespace).then(function(file) {
@@ -36,7 +36,7 @@ If a promise library is already loaded externally you can specify 'global'.
 You can optionally specify [a name for your chunk](http://webpack.github.io/docs/code-splitting.html#named-chunks) after a comma:
 
 ```javascript
-var load = require("promise?editor!./editor.js");
+var load = require("es6-promise?editor!./editor.js");
 ```
 
 This can be useful for [single-page apps](http://webpack.github.io/docs/optimization.html#single-page-app) because you can later extract filenames from [Webpack-generated stats](https://github.com/webpack/docs/wiki/node.js-api#stats) and pre-load specific bundles if you know user's going to hit them.
@@ -46,7 +46,7 @@ The bundle name may include `[filename]`, which will be replaced with the filena
 ```javascript
 {
   test: /\.i18n\.json$/,
-  loader: 'promise?global,[name].i18n'
+  loader: 'es6-promise?global,[name].i18n'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,7 @@ It only implements so-called `lazy` `bundle-loader` mode—that is, `require` re
 
 `require: (string) -> () -> Promise<module>`
 
-It's up to you to specify your Promise library of choice as a parameter.
-
 ``` javascript
-// Assuming you use Bluebird
 var load = require("es6-promise!./file.js");
 
 // The chunk is not requested until you call the load function
@@ -30,8 +27,6 @@ load(namespace).then(function(file) {
     }
 ```
 
-If a promise library is already loaded externally you can specify 'global'.
-
 
 You can optionally specify [a name for your chunk](http://webpack.github.io/docs/code-splitting.html#named-chunks) after a comma:
 
@@ -46,7 +41,7 @@ The bundle name may include `[filename]`, which will be replaced with the filena
 ```javascript
 {
   test: /\.i18n\.json$/,
-  loader: 'es6-promise?global,[name].i18n'
+  loader: 'es6-promise?[name].i18n'
 }
 ```
 


### PR DESCRIPTION
It looks like the `README` for this project was copied from [gaeron/promise-loader](https://github.com/gaearon/promise-loader), but it does not match the actual implementation. This pull request fixes uses of `promise-loader` (or `promise`) with `es6-promise-loader` (or `es6-promise` for short). It also removes references to specifying a promise implementation, since that is not a feature of this loader.
